### PR TITLE
Fix timestamp handling for webhooks

### DIFF
--- a/messengerbot/webhooks.py
+++ b/messengerbot/webhooks.py
@@ -7,7 +7,7 @@ class WebhookMessaging(object):
     def __init__(self, sender, recipient, timestamp, **kwargs):
         self.sender = Recipient(recipient_id=sender['id'])
         self.recipient = Recipient(recipient_id=sender['id'])
-        self.timestamp = datetime.utcfromtimestamp(timestamp)
+        self.timestamp = datetime.utcfromtimestamp(timestamp/1000)
 
         for key, value in kwargs.items():
             self.__dict__['_%s' % key] = value
@@ -30,7 +30,7 @@ class WebhookEntry(object):
     def __init__(self, id, time, messaging):
         self.id = id
         # TODO parse epoch
-        self.time = datetime.utcfromtimestamp(time)
+        self.time = datetime.utcfromtimestamp(time/1000)
         self.messaging = [
             WebhookMessaging(**each)
             for each in messaging

--- a/tests/test_webhooks.py
+++ b/tests/test_webhooks.py
@@ -7,22 +7,29 @@ class WebhookTestCase(TestCase):
 
     def setUp(self):
         self.payload = {
-            "object": "page",
-            "entry": [{
-                "id": '123',
-                "time": 1460905554,
-                "messaging": [
-                    {
-                        "sender": {
-                            "id": '1234'
-                        },
-                        "recipient": {
-                            "id": '1234'
-                        },
-                        "timestamp": 1460905554
-                    }
-                ]
-            }]
+          "object":"page",
+          "entry":[
+            {
+              "id":"PAGE_ID",
+              "time":1460245674269,
+              "messaging":[
+                {
+                  "sender":{
+                    "id":"USER_ID"
+                  },
+                  "recipient":{
+                    "id":"PAGE_ID"
+                  },
+                  "timestamp":1460245672080,
+                  "message":{
+                    "mid":"mid.1460245671959:dad2ec9421b03d6f78",
+                    "seq":216,
+                    "text":"hello"
+                  }
+                }
+              ]
+            }
+          ]
         }
 
     def test_message_webhook(self):


### PR DESCRIPTION
The webhooks timestamp handling was implemented for second resolution rather than the millisecond resolution provided by Facebook. I've updated that and copied the example data provided by Facebook [on this page](https://developers.facebook.com/docs/messenger-platform/implementation) into the test, which still passes.
