### PR TITLE
to_dict fix for Recipient

### DIFF
--- a/messengerbot/messages.py
+++ b/messengerbot/messages.py
@@ -27,9 +27,12 @@ class Recipient(object):
         self.phone_number = phone_number
 
     def to_dict(self):
+        data = {}
         if self.recipient_id:
-            return {'id': self.recipient_id}
-        return {'phone_number': self.phone_number}
+            data['id'] = self.recipient_id
+        if self.phone_number:
+            data['phone_number'] = self.phone_number
+        return data
 
 
 class MessageRequest(object):


### PR DESCRIPTION
```
In [23]: recp = Recipient(123, 345)

In [24]: recp.to_dict()
Out[24]: {'id': 123}
```

`to_dict()` , dictionary does not have `phone_number`even though instance has phone_number value
