### PR TITLE
Add call to get facebook user profile from recipient

### DIFF
--- a/messengerbot/users.py
+++ b/messengerbot/users.py
@@ -1,0 +1,33 @@
+import requests
+from messengerbot import MessengerError
+
+class MessengerUserProfile(object):
+    available_fields = ['first_name',
+                        'last_name',
+                        'profile_pic',
+                        'locale',
+                        'timezone',
+                        'gender']
+    GRAPH_API_BASE_URL = 'https://graph.facebook.com/v2.6/'
+
+    def __init__(self, access_token, recipient):
+        self.access_token = access_token
+        self.recipient = recipient
+        for af in self.available_fields:
+            setattr(self, af, None)
+
+    def get_user_profile(self):
+        fields = ','.join(self.available_fields)
+        url = '{}{}'.format(self.GRAPH_API_BASE_URL, self.recipient.recipient_id)
+        params = {'access_token': self.access_token,
+                  'fields' : fields}
+        response = requests.get(url, params=params)
+        if response.status_code != 200:
+            MessengerError(
+                **response.json()['error']
+                ).raise_exception()
+        json_response = response.json()
+        for af in self.available_fields:
+            if af in json_response:
+                setattr(self, af, json_response[af])
+        return json_response

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,52 @@
+from unittest import TestCase
+from messengerbot import MessengerClient, messages, MessengerException, users
+from mock import patch
+
+
+class UserTestCase(TestCase):
+
+    @patch('requests.get')
+    def test_get_user_profile(self, mock_get):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {
+          "first_name": "Peter",
+          "last_name": "Chang",
+          "profile_pic": "https://fbcdn-profile-a.akamaihd.net/hprofile-ak-xpf1/v/t1.0-1/p200x200/13055603_10105219398495383_8237637584159975445_n.jpg?oh=1d241d4b6d4dac50eaf9bb73288ea192&oe=57AF5C03&__gda__=1470213755_ab17c8c8e3a0a447fed3f272fa2179ce",
+          "locale": "en_US",
+          "timezone": -7,
+          "gender": "male"
+        }
+        recipient = messages.Recipient(recipient_id='123')
+        messenger_user_profile = users.MessengerUserProfile(access_token='1234',
+                                                      recipient=recipient)
+        result = messenger_user_profile.get_user_profile()
+
+        mock_get.assert_called_with(
+            'https://graph.facebook.com/v2.6/123',
+            params={'access_token': '1234',
+                    'fields' : 'first_name,last_name,profile_pic,locale,timezone,gender' }
+        )
+
+    @patch('requests.get')
+    def test_client_send_error_with_error_data(self, mock_get):
+        mock_get.return_value.status_code = 190
+        mock_get.return_value.json.return_value = {
+            "error":{
+                     "message":"Invalid parameter",
+                     "type":"FacebookApiException",
+                     "code":100,
+                     "error_data":"No matching user found.",
+                     "fbtrace_id":"D2kxCybrKVw"
+                     }
+        }
+
+        recipient = messages.Recipient(recipient_id='123')
+        messenger_user_profile = users.MessengerUserProfile(access_token='1234',
+                                                      recipient=recipient)
+        self.assertRaises(MessengerException,
+                          messenger_user_profile.get_user_profile)
+        mock_get.assert_called_with(
+            'https://graph.facebook.com/v2.6/123',
+            params={'access_token': '1234',
+                    'fields' : 'first_name,last_name,profile_pic,locale,timezone,gender' }
+        )


### PR DESCRIPTION
I need to try to guess the language from the received messages, that can be done with some language processing algorithms. But, since the [messenger platform documentation](https://developers.facebook.com/docs/messenger-platform/user-profile) allows to fetch the **locale** from the user profile, I added the functionality into a separate _users.py_ file, instead. 

I'm not sure if it is the best place to put it, because now we have two places where we specify the GRAPH_API_[BASE]_URL (the main MessengerClient has the **/me** at the end of the url hardcoded). Another option could be add a call to MessengerClient instead of the separate object, but I preferred to leave the decision to the maintainer.  
