### PR TITLE
Added header functionality to send method in __init__.py

### DIFF
--- a/messengerbot/__init__.py
+++ b/messengerbot/__init__.py
@@ -27,9 +27,13 @@ class MessengerClient(object):
         params = {
             'access_token': self.access_token
         }
+        headers = {
+            "Content-Type": "application/json"
+        }
         response = requests.post(
             '%s/messages' % self.GRAPH_API_URL,
             params=params,
+            headers=headers,
             json=message.to_dict()
         )
         if response.status_code != 200:


### PR DESCRIPTION
The Facebook Messenger API requires this header for json content. This package wasn't fully functional for me in all cases without this header. The current format may be out of date, or simply wrong. In any case, I propose this branch be merged.

Take a look at Facebook's [Messenger API documentation for buttons](https://developers.facebook.com/docs/messenger-platform/send-api-reference/button-template), for example. POST requests are sent with the header `"Content-Type: application/json"`, which is not part of this package's current formatting.